### PR TITLE
Fix current version

### DIFF
--- a/podlove-simple-chapters.md
+++ b/podlove-simple-chapters.md
@@ -50,7 +50,7 @@ There **must** be only one `<psc:chapters>` element. Clients **should** ignore e
 The `<psc:chapters>` element accepts one attribute:
 
 >**version="number"**
-:    Specifies the version of this specification (current version is 1.1). This enables future enhancements of this standard. This attribute is optional and defaults to "1.0".
+:    Specifies the version of this specification (current version is 1.2). This enables future enhancements of this standard. This attribute is optional and defaults to "1.0".
 
 ### <psc:chapter> ###
 


### PR DESCRIPTION
According to https://podlove.org/2013/03/31/psc-1-2/, the current version is 1.2. This should be reflected in the document.